### PR TITLE
Add immutable config class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "pinepain/simple-config",
-  "type": "library",
   "description": "Lightweight and flexible library for configuration management",
+  "type": "library",
   "keywords": [
     "lightweight",
     "micro",
@@ -21,7 +21,7 @@
     "nikic/php-parser": "1.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.*",
+    "phpunit/phpunit": "^4.8",
     "mikey179/vfsStream": "1.*"
   },
   "autoload": {

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -6,11 +6,6 @@ namespace Pinepain\SimpleConfig;
 interface ConfigInterface
 {
     /**
-     * @param array | \ArrayObject $items
-     */
-    public function __construct($items);
-
-    /**
      * Get all of the configuration items.
      *
      * @return array

--- a/src/ImmutableConfig.php
+++ b/src/ImmutableConfig.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Pinepain\SimpleConfig;
+
+
+class ImmutableConfig implements ConfigInterface
+{
+    private $config;
+
+    public function __construct(ConfigInterface $config)
+    {
+        $this->config = $config;
+    }
+
+    public function all()
+    {
+        return $this->config->all();
+    }
+
+    public function has($key)
+    {
+        return $this->config->has($key);
+    }
+
+    public function get($key, $default = null)
+    {
+        return $this->config->get($key, $default);
+    }
+
+    public function set($key, $value = null)
+    {
+        throw new \RuntimeException("Can't set key '{$key}' on immutable config");
+    }
+}

--- a/tests/ImmutableConfigTest.php
+++ b/tests/ImmutableConfigTest.php
@@ -1,0 +1,77 @@
+<?php
+
+
+namespace Pinepain\SimpleConfig\Tests;
+
+
+use Pinepain\SimpleConfig\ImmutableConfig;
+
+
+class ImmutableConfigTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAll()
+    {
+        $config = $this->getMockBuilder('\Pinepain\SimpleConfig\ConfigInterface')
+                       ->setMethods(['all'])
+                       ->getMockForAbstractClass();
+
+        $config->expects($this->once())
+               ->method('all')
+               ->willReturn(['test' => 'all']);
+
+        $immutable = new ImmutableConfig($config);
+
+        $this->assertSame(['test' => 'all'], $immutable->all());
+    }
+
+
+    public function testHas()
+    {
+        $config = $this->getMockBuilder('\Pinepain\SimpleConfig\ConfigInterface')
+                       ->setMethods(['has'])
+                       ->getMockForAbstractClass();
+
+        $config->expects($this->exactly(2))
+               ->method('has')
+               ->withConsecutive(['exists'], ['missed'])
+               ->willReturnOnConsecutiveCalls(true, false);
+
+        $immutable = new ImmutableConfig($config);
+
+        $this->assertTrue($immutable->has('exists'));
+        $this->assertFalse($immutable->has('missed'));
+    }
+
+    public function testGet()
+    {
+        $config = $this->getMockBuilder('\Pinepain\SimpleConfig\ConfigInterface')
+                       ->setMethods(['get'])
+                       ->getMockForAbstractClass();
+
+        $config->expects($this->exactly(3))
+               ->method('get')
+               ->withConsecutive(['exists'], ['missed'], ['missed', 'default'])
+               ->willReturnOnConsecutiveCalls('existent', null, 'default');
+
+        $immutable = new ImmutableConfig($config);
+
+        $this->assertSame('existent', $immutable->get('exists'));
+        $this->assertSame(null, $immutable->get('missed'));
+        $this->assertSame('default', $immutable->get('missed', 'default'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Can't set key 'key' on immutable config
+     */
+    public function testSet()
+    {
+        $config = $this->getMockBuilder('\Pinepain\SimpleConfig\ConfigInterface')
+                       ->getMockForAbstractClass();
+
+        $immutable = new ImmutableConfig($config);
+
+        $immutable->set('key', 'value');
+    }
+
+}


### PR DESCRIPTION
Add `ImmutableConfig` class which should be used in a situation when modifying config array is not desired, e.g. to insure that your application doesn't use config as a registry/service locator or that is doesn't pass values between various internal components. While real usage may vary, the main idea of this class specified in it name and to restrict modifying config values after they were properly initialized.
